### PR TITLE
Include disk plugin stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ For example, `web1-i-1234567`.
 Otherwise the name will have 'local' as a postfix.
 For example, `web1-local`.
 
+    aerospike_collectd_disks:
+      - xvdb
+      - xvdc
+
+Controls the disks to monitor.
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,6 @@ aerospike_collectd_librato_password: TOKEN
 aerospike_collectd_aggregate_cpu: true
 aerospike_collectd_interval: 10
 aerospike_collectd_sourcename: "{{ inventory_hostname }}"
+aerospike_collectd_disks:
+  - xvdb
+  - xvdc

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -21,6 +21,14 @@ LoadPlugin df
   IgnoreSelected true
 </Plugin>
 
+LoadPlugin disk
+<Plugin "disk">
+  {% for disk in aerospike_collectd_disks %}
+  Disk "{{ disk }}"
+  {% endfor %}
+  IgnoreSelected false
+</Plugin>
+
 LoadPlugin swap
 <Plugin "swap">
   ReportByDevice false


### PR DESCRIPTION
Useful to track Aerospike performance on cloud hosting such as AWS.